### PR TITLE
コメント機能のコードの冗長性改善（class_nameオプションの使用）

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
-  has_many :task_comments, dependent: :destroy
+  has_many :comments, class_name: "TaskComment", dependent: :destroy
 
   # バリデーション
   validates :title, length: { maximum: 30 }, presence: true

--- a/app/views/public/tasks/index.html.erb
+++ b/app/views/public/tasks/index.html.erb
@@ -18,7 +18,7 @@
           <span class="task-meta">
             <%= task.user.name %> / 
             <%= task.created_at.in_time_zone('Tokyo').strftime('%m月%d日 %H:%M') %> / 
-            <%= task.task_comments.count %> コメント
+            <%= task.comments.count %> コメント
           </span>
           <b><%= link_to task.title, task_path(task.id) %></b> 
         </div>

--- a/app/views/public/tasks/show.html.erb
+++ b/app/views/public/tasks/show.html.erb
@@ -47,11 +47,11 @@
   <div class="index-card">
     <div class="index-header">
       <ul>
-        <b>コメント件数：<%= @task.task_comments.count %></b>
+        <b>コメント件数：<%= @task.comments.count %></b>
         <hr size="10">
         <p></p>
         <!-- コメント表示 -->
-        <% @task.task_comments.each do |task_comment| %>
+        <% @task.comments.each do |task_comment| %>
           <li class="comment">
             <div class="comment-container">
               <div class="comment-image">

--- a/app/views/public/tasks/show.html.erb
+++ b/app/views/public/tasks/show.html.erb
@@ -69,7 +69,7 @@
                   <%= task_comment.user.name %>
                   <%= task_comment.created_at.in_time_zone('Tokyo').strftime('%m月%d日 %H:%M') %>
                   <% if task_comment.user == current_user %>
-                    <%= link_to "削除", task_task_comment_path(task_comment.task, task_comment), method: :delete %>
+                    <%= link_to "削除", task_comment_path(task_comment.task, task_comment), method: :delete %>
                   <% end %>
                 </span>
               </div>
@@ -79,7 +79,9 @@
           <hr size="10">
         <% end %>
         <!-- コメント投稿フォーム -->
-        <%= form_with model:[@task, @task_comment] do |f| %>
+        <%= form_with model: @task_comment, url: task_comments_path(@task), local: true do |f| %>
+
+        
           <%= f.text_area :comment, placeholder: "コメントを入力", class: "form-input-comment" %>
           <%= button_tag(type: 'submit', class: 'submit-btn') do %>
             <i class="fa-solid fa-paper-plane"></i>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -40,7 +40,7 @@
                   <span class="task-title"><%= link_to task.title, task_path(task.id) %></span>
                   <span class="task-meta-detail">
                     <%= task.updated_at.in_time_zone('Tokyo').strftime('%m月%d日 %H:%M') %> / 
-                    <%= task.task_comments.count %> コメント
+                    <%= task.comments.count %> コメント
                   </span>
                 </div>
               </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
 
     # tasksコントローラのルーティング
     resources :tasks, only: [:new, :create, :index, :show, :edit, :update, :destroy] do
-      resources :task_comments, only: [:create, :destroy]
+      resources :task_comments, only: [:create, :destroy], as: "comments"
     end
 
     # usersコントローラのルーティング


### PR DESCRIPTION
tasks/show.html.erbが長いため、下記の対応をする。

- class_nameオプションを使用する
- task_task_comment_path部分を修正（asを使う）